### PR TITLE
Allow ~2.4 or ~3.0 symfony http foundation package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "symfony/http-foundation": "2.4.x-dev",
+        "symfony/http-foundation": "~2.4|~3.0",
         "predis/predis": "0.8.x-dev"
     },
     


### PR DESCRIPTION
This removes the hard-dependency on `2.4.x-dev` Symfony HTTP foundation
